### PR TITLE
Fix looping while resolving project dependencies.

### DIFF
--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
@@ -183,8 +183,8 @@ object CheckLicenses {
     }
 
     fun resolveProjectDependencies(
-            project: Project,
-            ignoredProjects: Set<String>
+        project: Project,
+        ignoredProjects: Set<String>
     ): Set<ResolvedArtifact> {
         val projectNamesToSkip = ignoredProjects.toMutableSet()
         return getProjectDependencies(project, projectNamesToSkip)
@@ -193,8 +193,8 @@ object CheckLicenses {
     }
 
     private fun getProjectDependencies(
-            project: Project?,
-            projectNamesToSkip: MutableSet<String>
+        project: Project?,
+        projectNamesToSkip: MutableSet<String>
     ): Sequence<ResolvedArtifact> {
         project ?: return emptySequence()
         if (project.name in projectNamesToSkip) return emptySequence()

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
@@ -182,36 +182,37 @@ object CheckLicenses {
         )
     }
 
-    @VisibleForTesting
     fun resolveProjectDependencies(
-        project: Project?,
-        ignoredProjects: Set<String> = emptySet()
+            project: Project,
+            ignoredProjects: Set<String>
     ): Set<ResolvedArtifact> {
-        project ?: return emptySet()
-        val subProjects =
-            targetSubProjects(
-                project,
-                ignoredProjects
-            )
-        val subProjectIndex = subProjects.groupBy { it.toFormattedText() }
-        return subProjects
+        val projectNamesToSkip = ignoredProjects.toMutableSet()
+        return getProjectDependencies(project, projectNamesToSkip)
+            .distinctBy { it.toFormattedText() }
+            .toSet()
+    }
+
+    private fun getProjectDependencies(
+            project: Project?,
+            projectNamesToSkip: MutableSet<String>
+    ): Sequence<ResolvedArtifact> {
+        project ?: return emptySequence()
+        if (project.name in projectNamesToSkip) return emptySequence()
+        projectNamesToSkip.add(project.name)
+        val subProjects = targetSubProjects(project, projectNamesToSkip).associateBy {
+            it.toFormattedText()
+        }
+        return (sequenceOf(project) + subProjects.values)
             .map { it.configurations }
             .flatten()
-            .filter {
-                isConfigForDependencies(
-                    it.name
-                )
-            }
+            .filter { isConfigForDependencies(it.name) }
             .map { it.resolvedArtifacts() }
             .flatten()
             .distinctBy { it.toFormattedText() }
             .flatMap {
-                val dependencyDesc = it.toFormattedText()
-                val subProject = subProjectIndex[dependencyDesc]?.first()
-                setOf(it, *resolveProjectDependencies(
-                    subProject
-                ).toTypedArray())
-            }.toSet()
+                val subProject = subProjects[it.toFormattedText()]
+                sequenceOf(it) + getProjectDependencies(subProject, projectNamesToSkip)
+            }
     }
 
     private val dependencyKeywordPattern =


### PR DESCRIPTION
## Background

Currently we use https://github.com/cookpad/license-tools-plugin. Thanks for it, however, as announced in [this post](https://techlife.cookpad.com/entry/2020/01/16/090000), it has been archived, suggesting  this `LicenseToolsPlugin` instead. 

So now we are trying to adopt the new library, and unfortunately I found an issue that would make it unable to migrate. I would like to submit this PR as a patch to resolve it, I appreciate if it would be kindly accepted by maintainers. I hope this submission would help other developers as well. 

## Issue

For multi module projects, `checkLicenses` task could continue forever for looping while resolving project dependencies.
 - It has not occurred with the archived version, so it seems a newly-introduced behavior difference.

## Why?

This is because:

```kt
// in CheckLicenses.kt
    fun targetSubProjects(project: Project, ignoredProjects: Set<String>): List<Project> {
        return project.rootProject.subprojects
            .filter { !ignoredProjects.contains(it.name) }
    }
```

the function above returns a list of `Project`, it could be siblings of  the `project` given, including itself. `CheckLicenses.resolveProjectDependencies()` tries to resolve dependencies recursively for any project in the list, without excluding what it had checked, resulting in the loop issue.

##  How to fix? (upcoming changes)

 - Just simply, update the set of project names to skip, while traversing projects.
    - The name set is created as a mutable copy of `ignoredProjects`, so it won't modify the original set, of course. No breaking side effect to outside.
 - tweaked a bit for efficiency, applying such as `sequence` and `associateBy`.

Locally with our project I confirmed the patch worked as expected, although I cannot share the project's source unfortunately. 