### PR TITLE
Update Copyright text

### DIFF
--- a/plugin/src/main/java/com/cookpad/android/plugin/license/LicenseToolsPlugin.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/LicenseToolsPlugin.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license
 
 import com.cookpad.android.plugin.license.task.CheckLicenses

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/LicenseToolsPluginExtension.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/LicenseToolsPluginExtension.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license
 
 open class LicenseToolsPluginExtension {

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/Templates.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/Templates.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license
 
 import com.cookpad.android.plugin.license.data.LibraryInfo

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/data/ArtifactId.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/data/ArtifactId.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.data
 
 data class ArtifactId(

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/data/LibraryInfo.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/data/LibraryInfo.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.data
 
 data class LibraryInfo(

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/data/LibraryPom.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/data/LibraryPom.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.data
 
 import org.simpleframework.xml.Attribute

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/exception/NotEnoughInformationException.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/exception/NotEnoughInformationException.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.exception
 
 import com.cookpad.android.plugin.license.data.LibraryInfo

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/extension/ConfigurationExtensions.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/extension/ConfigurationExtensions.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.extension
 
 import org.gradle.api.artifacts.Configuration

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/extension/FileExtensions.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/extension/FileExtensions.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.extension
 
 import java.io.File

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/extension/LibraryInfoSetExtensions.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/extension/LibraryInfoSetExtensions.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.extension
 
 import com.cookpad.android.plugin.license.data.ArtifactId

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/extension/ProjectExtensions.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/extension/ProjectExtensions.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.extension
 
 import com.cookpad.android.plugin.license.LicenseToolsPluginExtension

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/extension/ResolvedArtifactExtensions.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/extension/ResolvedArtifactExtensions.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.extension
 
 import org.gradle.api.artifacts.ResolvedArtifact

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.task
 
 import com.cookpad.android.plugin.license.LicenseToolsPluginExtension

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicenseJson.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicenseJson.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.task
 
 import com.cookpad.android.plugin.license.LicenseToolsPluginExtension

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicensePage.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicensePage.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.task
 
 import com.cookpad.android.plugin.license.LicenseToolsPluginExtension

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/UpdateLicenses.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/UpdateLicenses.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.task
 
 import com.cookpad.android.plugin.license.LicenseToolsPluginExtension

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/util/YamlUtils.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/util/YamlUtils.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.plugin.license.util
 
 import com.cookpad.android.plugin.license.data.ArtifactId


### PR DESCRIPTION
I added SPDX identifier and copyright in source codes.

In the Linux project, they added the SPDX identifier to solve the open source License compliance in the source. Please take a loot at the pages.

1. https://www.linuxfoundation.org/blog/2018/08/solving-license-compliance-at-the-source-adding-spdx-license-ids/
2. https://spdx.org/using-spdx-license-identifier

So I contributed to add it in source codes of LicenseToolsPlugin.