### PR TITLE
Support nested sub-projects(sub-module)

### DIFF
--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
@@ -137,7 +137,9 @@ object CheckLicenses {
     @VisibleForTesting
     fun targetSubProjects(project: Project, ignoredProjects: Set<String>): List<Project> {
         return project.rootProject.subprojects
-            .filter { !ignoredProjects.contains(it.name) }
+            .filterNot {
+                ignoredProjects.contains(it.name) || ignoredProjects.contains(it.path) || it.subprojects.isNotEmpty()
+            }
     }
 
     @VisibleForTesting
@@ -158,11 +160,11 @@ object CheckLicenses {
         }
         val pomDependency = project.dependencies.create("$dependencyDesc@pom")
         val pomConfiguration = project.configurations.detachedConfiguration(pomDependency)
-        pomConfiguration.resolve().forEach { file ->
-            project.logger.info("POM: $file")
-        }
         val pomStream: File
         try {
+            pomConfiguration.resolve().forEach { file ->
+                project.logger.info("POM: $file")
+            }
             pomStream = pomConfiguration.resolve().toList().first()
         } catch (e: Exception) {
             project.logger.warn("Unable to retrieve license for $dependencyDesc")


### PR DESCRIPTION
close: https://github.com/cookpad/LicenseToolsPlugin/issues/26

Support nested sub-projects, like this

```
app
  |
  --- build.gradle
features
  |
  ---- feature_a
           |
            build.gradle
  |
  ---- feature_b
           |
            build.gradle
```

If you ignore nested sub-projects, you should write build.gradle like

```
licenseTools {
    ignoredProjects = [
            ':features:feature_b' // Need full project path.
    ]
}

```