### PR TITLE
#103 Dedup and sort licenses in updating licenses task

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-android:3.9.0'
+    testImplementation 'org.mockito:mockito-core:3.9.0'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "com.google.truth:truth:1.1.2"
 }

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/extension/LibraryInfoExtensions.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/extension/LibraryInfoExtensions.kt
@@ -1,0 +1,18 @@
+package com.cookpad.android.plugin.license.extension
+
+import com.cookpad.android.plugin.license.data.LibraryInfo
+
+internal fun LibraryInfo.generateLibraryInfoText(): String {
+    val text = StringBuffer()
+    text.append("- artifact: ${artifactId.withWildcardVersion()}\n")
+    text.append("  name: ${name ?: "#NAME#"}\n")
+    text.append("  copyrightHolder: ${copyrightHolder ?: "#COPYRIGHT_HOLDER#"}\n")
+    text.append("  license: ${license ?: "#LICENSE#"}\n")
+    if (licenseUrl?.isNotBlank() == true) {
+        text.append("  licenseUrl: ${licenseUrl}\n")
+    }
+    if (url?.isNotBlank() == true) {
+        text.append("  url: ${url}\n")
+    }
+    return text.toString().trim()
+}

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/CheckLicenses.kt
@@ -8,12 +8,12 @@ import com.cookpad.android.plugin.license.data.ArtifactId
 import com.cookpad.android.plugin.license.data.LibraryInfo
 import com.cookpad.android.plugin.license.data.LibraryPom
 import com.cookpad.android.plugin.license.extension.duplicatedArtifacts
+import com.cookpad.android.plugin.license.extension.generateLibraryInfoText
 import com.cookpad.android.plugin.license.extension.licensesUnMatched
 import com.cookpad.android.plugin.license.extension.notListedIn
 import com.cookpad.android.plugin.license.extension.resolvedArtifacts
 import com.cookpad.android.plugin.license.extension.toFormattedText
 import com.cookpad.android.plugin.license.util.YamlUtils
-import java.io.File
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting
 import org.simpleframework.xml.Serializer
 import org.simpleframework.xml.core.Persister
+import java.io.File
 
 object CheckLicenses {
     fun register(project: Project): Task {
@@ -62,10 +63,7 @@ object CheckLicenses {
                     .distinctBy { it.artifactId.withWildcardVersion() }
                     .sortedBy { it.artifactId.withWildcardVersion() }
                     .forEach { libraryInfo ->
-                        val text =
-                            generateLibraryInfoText(
-                                libraryInfo
-                            )
+                        val text = libraryInfo.generateLibraryInfoText()
                         project.logger.warn(text)
                     }
             }
@@ -99,22 +97,6 @@ object CheckLicenses {
             it.group = "Verification"
             it.description = "Check whether dependency licenses are listed in licenses.yml"
         }
-    }
-
-    @VisibleForTesting
-    fun generateLibraryInfoText(libraryInfo: LibraryInfo): String {
-        val text = StringBuffer()
-        text.append("- artifact: ${libraryInfo.artifactId.withWildcardVersion()}\n")
-        text.append("  name: ${libraryInfo.name ?: "#NAME#"}\n")
-        text.append("  copyrightHolder: ${libraryInfo.copyrightHolder ?: "#COPYRIGHT_HOLDER#"}\n")
-        text.append("  license: ${libraryInfo.license ?: "#LICENSE#"}\n")
-        if (libraryInfo.licenseUrl?.isNotBlank() == true) {
-            text.append("  licenseUrl: ${libraryInfo.licenseUrl}\n")
-        }
-        if (libraryInfo.url?.isNotBlank() == true) {
-            text.append("  url: ${libraryInfo.url}\n")
-        }
-        return text.toString().trim()
     }
 
     @VisibleForTesting

--- a/plugin/src/test/java/com/cookpad/android/plugin/license/task/UpdateLicensesTest.kt
+++ b/plugin/src/test/java/com/cookpad/android/plugin/license/task/UpdateLicensesTest.kt
@@ -1,0 +1,58 @@
+package com.cookpad.android.plugin.license.task
+
+import com.cookpad.android.plugin.license.loadYamlFromResources
+import com.cookpad.android.plugin.license.util.YamlUtils
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.whenever
+import org.gradle.api.Project
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
+
+@RunWith(MockitoJUnitRunner::class)
+class UpdateLicensesTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+    private lateinit var licensesYamlFile: File
+
+    @Mock
+    lateinit var project: Project
+
+    @Before
+    fun setUp() {
+        licensesYamlFile = tempFolder.newFile()
+        whenever(project.file(FILENAME_LICENSES_YAML)) doReturn licensesYamlFile
+    }
+
+    @After
+    fun tearDown() {
+        licensesYamlFile.delete()
+    }
+
+    @Test
+    fun updateLicensesYaml_duplicatedDependencies_dedupsAndSortsDependencies() {
+        val licenses = loadYamlFromResources("yaml/duplicated_unsorted_licenses.yml")
+        assertThat(licenses.size).isEqualTo(4)
+        UpdateLicenses.updateLicensesYaml(project, FILENAME_LICENSES_YAML, licenses)
+
+        val result = YamlUtils.loadToLibraryInfo(licensesYamlFile)
+
+        val expected = loadYamlFromResources("yaml/dedup_sorted_licenses.yml")
+        assertThat(result.size).isEqualTo(expected.size)
+        for ((index, info) in result.withIndex()) {
+            assertThat(info).isEqualTo(expected[index])
+        }
+    }
+
+    companion object {
+        private const val FILENAME_LICENSES_YAML = "licenses.yml"
+    }
+}

--- a/plugin/src/test/resources/yaml/dedup_sorted_licenses.yml
+++ b/plugin/src/test/resources/yaml/dedup_sorted_licenses.yml
@@ -1,0 +1,17 @@
+- artifact: com.google.android.play:core:+
+  name: core
+  copyrightHolder: Google Inc.
+  license: Play Core Software Development Kit Terms of Service
+  licenseUrl: https://developer.android.com/guide/playcore/license
+- artifact: org.jetbrains.kotlinx:kotlinx-coroutines-android:+
+  name: kotlinx-coroutines-android
+  copyrightHolder: JetBrains s.r.o.
+  license: The Apache Software License, Version 2.0
+  licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
+  url: https://github.com/Kotlin/kotlinx.coroutines
+- artifact: org.jetbrains.kotlinx:kotlinx-coroutines-core-common:+
+  name: kotlinx-coroutines-core-common
+  copyrightHolder: JetBrains s.r.o.
+  license: The Apache Software License, Version 2.0
+  licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
+  url: https://github.com/Kotlin/kotlinx.coroutines

--- a/plugin/src/test/resources/yaml/duplicated_unsorted_licenses.yml
+++ b/plugin/src/test/resources/yaml/duplicated_unsorted_licenses.yml
@@ -1,0 +1,24 @@
+- artifact: org.jetbrains.kotlinx:kotlinx-coroutines-android:+
+  name: kotlinx-coroutines-android
+  copyrightHolder: JetBrains s.r.o.
+  license: The Apache Software License, Version 2.0
+  licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
+  url: https://github.com/Kotlin/kotlinx.coroutines
+- artifact: com.google.android.play:core:+
+  name: core
+  copyrightHolder: Google Inc.
+  license: Play Core Software Development Kit Terms of Service
+  licenseUrl: https://developer.android.com/guide/playcore/license
+- artifact: org.jetbrains.kotlinx:kotlinx-coroutines-core-common:+
+  name: kotlinx-coroutines-core-common
+  copyrightHolder: JetBrains s.r.o.
+  license: The Apache Software License, Version 2.0
+  licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
+  url: https://github.com/Kotlin/kotlinx.coroutines
+# Duplicated artifact id
+- artifact: org.jetbrains.kotlinx:kotlinx-coroutines-core-common:+
+  name: kotlinx-coroutines-core-common
+  copyrightHolder: JetBrains s.r.o.
+  license: The Apache Software License, Version 2.0
+  licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
+  url: https://github.com/Kotlin/kotlinx.coroutines


### PR DESCRIPTION
To make licenses YAML file easy to be review and manage,
we should keep licenses a fixed order which is the alphabetical sort by
licence artifact ids.

Test: unit tests pass