### PR TITLE
#105 Provide error messages for developers in the "generateLicensePage" task

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-android:3.9.0'
+    testImplementation 'org.mockito:mockito-core:3.9.0'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "com.google.truth:truth:1.1.2"
 }

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/Templates.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/Templates.kt
@@ -6,22 +6,26 @@ package com.cookpad.android.plugin.license
 import com.cookpad.android.plugin.license.data.LibraryInfo
 import com.cookpad.android.plugin.license.exception.NotEnoughInformationException
 import groovy.text.SimpleTemplateEngine
+import org.codehaus.groovy.runtime.DefaultGroovyMethods
+import org.codehaus.groovy.runtime.IOGroovyMethods
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.net.JarURLConnection
 import java.net.URISyntaxException
 import java.net.URL
-import java.util.LinkedHashMap
 import java.util.zip.ZipFile
-import org.codehaus.groovy.runtime.DefaultGroovyMethods
-import org.codehaus.groovy.runtime.IOGroovyMethods
 
 object Templates {
 
     private val templateEngine = SimpleTemplateEngine()
 
-    @Throws(IOException::class, URISyntaxException::class, ClassNotFoundException::class)
+    @Throws(
+        IOException::class,
+        URISyntaxException::class,
+        ClassNotFoundException::class,
+        NotEnoughInformationException::class
+    )
     fun buildLicenseHtml(library: LibraryInfo): String {
         assertLicenseAndStatement(
             library
@@ -41,16 +45,20 @@ object Templates {
         return templateEngine.createTemplate(templateText).make(map).toString()
     }
 
+    @Throws(NotEnoughInformationException::class)
     private fun assertLicenseAndStatement(library: LibraryInfo) {
         if (library.license.isNullOrBlank()) {
             throw NotEnoughInformationException(
-                library
+                library,
+                "Missing info in the \"license\" field"
             )
         }
 
         if (library.getCopyrightStatement() == null) {
             throw NotEnoughInformationException(
-                library
+                library,
+                "Could not generate the copyright statement. " +
+                    "Please provide either the \"notice\" field or the \"copyrightHolder\" field."
             )
         }
     }

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/exception/NotEnoughInformationException.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/exception/NotEnoughInformationException.kt
@@ -5,4 +5,7 @@ package com.cookpad.android.plugin.license.exception
 
 import com.cookpad.android.plugin.license.data.LibraryInfo
 
-class NotEnoughInformationException(val libraryInfo: LibraryInfo) : RuntimeException()
+class NotEnoughInformationException(
+    libraryInfo: LibraryInfo,
+    missingInfo: String
+) : RuntimeException("Library: ${libraryInfo.artifactId.withWildcardVersion()} $missingInfo")

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicensePage.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicensePage.kt
@@ -6,8 +6,10 @@ package com.cookpad.android.plugin.license.task
 import com.cookpad.android.plugin.license.LicenseToolsPluginExtension
 import com.cookpad.android.plugin.license.Templates
 import com.cookpad.android.plugin.license.data.LibraryInfo
+import com.cookpad.android.plugin.license.exception.NotEnoughInformationException
 import com.cookpad.android.plugin.license.extension.writeLicenseHtml
 import com.cookpad.android.plugin.license.util.YamlUtils
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting
@@ -17,15 +19,28 @@ object GenerateLicensePage {
         return project.task("generateLicensePage").doLast {
             val ext = project.extensions.getByType(LicenseToolsPluginExtension::class.java)
             val yamlInfoList = YamlUtils.loadToLibraryInfo(project.file(ext.licensesYaml))
-            project.writeLicenseHtml(yamlInfoList.toHtml())
+            project.writeLicenseHtml(yamlInfoList.toHtml(project))
         }
     }
 
     @VisibleForTesting
-    fun List<LibraryInfo>.toHtml(): String {
+    fun List<LibraryInfo>.toHtml(project: Project): String {
         val licenseHtml = StringBuffer()
+        var hasError = false
         this.filterNot { it.skip ?: false }
-            .forEach { licenseHtml.append(Templates.buildLicenseHtml(it)) }
+            .forEach {
+                try {
+                    licenseHtml.append(Templates.buildLicenseHtml(it))
+                } catch (exception: NotEnoughInformationException) {
+                    // Print all libraries aren't enough information for develops to fix them.
+                    hasError = true
+                    project.logger.warn(exception.message)
+                }
+            }
+        if (hasError) {
+            throw GradleException("generateLicensePage: more than one library isn't enough information")
+        }
+
         return Templates.wrapWithLayout(licenseHtml)
     }
 }

--- a/plugin/src/test/java/com/cookpad/android/plugin/license/task/GenerateLicensePageTest.kt
+++ b/plugin/src/test/java/com/cookpad/android/plugin/license/task/GenerateLicensePageTest.kt
@@ -2,13 +2,51 @@ package com.cookpad.android.plugin.license.task
 
 import com.cookpad.android.plugin.license.loadYamlFromResources
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
 
+@RunWith(MockitoJUnitRunner::class)
 class GenerateLicensePageTest {
+
+    @Mock
+    lateinit var project: Project
+
+    @Mock
+    lateinit var logger: Logger
+
+    @Before
+    fun setUp() {
+        whenever(project.logger) doReturn logger
+    }
+
     @Test
     fun toHtml_isSuccess() = GenerateLicensePage.run {
         val yamlInfoList = loadYamlFromResources("yaml/licenses.yml")
-        val htmlString = yamlInfoList.toHtml()
+        val htmlString = yamlInfoList.toHtml(project)
         assertThat(htmlString).doesNotContain("null")
+    }
+
+    @Test
+    fun toHtml_notEnoughInfo_printsAllErrorAndThrowsGradleException() = GenerateLicensePage.run {
+        val yamlInfoList = loadYamlFromResources("yaml/not_enough_info_licenses.yaml")
+        try {
+            yamlInfoList.toHtml(project)
+            fail()
+        } catch (expected: GradleException) {
+        }
+
+        verify(logger, times(2)).warn(any())
     }
 }

--- a/plugin/src/test/resources/yaml/not_enough_info_licenses.yaml
+++ b/plugin/src/test/resources/yaml/not_enough_info_licenses.yaml
@@ -1,0 +1,15 @@
+- artifact: com.moat.analytics.mobile.mpub:moat-mobile-app-kit:+
+  name: moat-mobile-app-kit
+  copyrightHolder: Moat
+  license: #LICENSE#
+  licenseUrl: https://s3.amazonaws.com/moat-sdk-builds/license/LICENSE.txt
+- artifact: org.yaml:snakeyaml:+
+  name: SnakeYAML
+  copyrightHolder: #COPYRIGHT_HOLDER#
+  license: Apache License, Version 2.0
+  licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
+  url: http://www.snakeyaml.org
+- artifact: com.squareup.okio:okio:+
+  name: Okio
+  copyrightHolder: Square, Inc.
+  license: apache2


### PR DESCRIPTION
We didn't provide any error message before, and it is hard to know what happens when generating licenses page.
Print error messages for develops to fix them in "generateLicensePage"
task.

Test: unit tests pass