### PR TITLE
Remove JCenter dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.moshi_version = '1.12.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
     dependencies {
@@ -18,7 +18,6 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,7 +3,7 @@
 //buildscript {
 //    repositories {
 //        google()
-//        jcenter()
+//        mavenCentral()
 //        mavenLocal()
 //    }
 //    dependencies {


### PR DESCRIPTION
## Overview

JFog has announced JCenter became read-only repository since it stopped new package versions submission.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

And also [Android Developers Documentation](https://developer.android.com/studio/build/jcenter-migration) suggests to find new location.

This PR replaces JCenter with Maven Central.

I've tested these commands complete successfully.
```
./gradlew --refresh-dependencies
./gradlew test
```