### PR TITLE
Customizable html template style

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Available configuration fields:
 | `outputJson`      | `"licenses.json"`  | The file name of the output of the `generateLicenseJson` task                                              |
 | `ignoredGroups`   | `[]` (empty array) | An array of group names the plugin will ignore (useful for internal dependencies with missing .pom files)  |
 | `ignoredProjects` | `[]` (empty array) | An array of project names the plugin will ignore (To ignore particular internal projects like custom lint) |
+| `customStyles`    | `""`               | The additional style of the output of the `generateLicensePage` task HTML file.                     |
 
 ## DataSet Format
 

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/LicenseToolsPluginExtension.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/LicenseToolsPluginExtension.kt
@@ -14,6 +14,8 @@ open class LicenseToolsPluginExtension {
 
     var ignoredProjects = emptySet<String>()
 
+    var customStyles = ""
+
     companion object {
         const val NAME = "licenseTools"
     }

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/Templates.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/Templates.kt
@@ -63,11 +63,12 @@ object Templates {
         }
     }
 
-    fun wrapWithLayout(content: CharSequence): String {
+    fun wrapWithLayout(content: CharSequence, customStyle: String): String {
         val templateFile = "template/layout.html"
         val map = LinkedHashMap<String, String>(1)
         map["content"] =
             makeIndent(content, 4)
+        map["custom_css"] = customStyle
         return templateEngine.createTemplate(
             readResourceContent(
                 templateFile

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicensePage.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicensePage.kt
@@ -41,6 +41,9 @@ object GenerateLicensePage {
             throw GradleException("generateLicensePage: more than one library isn't enough information")
         }
 
-        return Templates.wrapWithLayout(licenseHtml)
+        return Templates.wrapWithLayout(
+            licenseHtml,
+            project.extensions.getByType(LicenseToolsPluginExtension::class.java).customStyles.trimIndent()
+        )
     }
 }

--- a/plugin/src/main/resources/template/layout.html
+++ b/plugin/src/main/resources/template/layout.html
@@ -72,6 +72,7 @@
     input:checked ~ .license {
     max-height: none;
     }
+    ${custom_css}
   </style>
 </head>
 <body>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -55,6 +55,8 @@ licenseTools {
     ignoredProjects = [
             'plugin',
     ]
+
+    customStyles = file('custom_style.css').text
 }
 
 dependencies {

--- a/sample/custom_style.css
+++ b/sample/custom_style.css
@@ -1,0 +1,3 @@
+body{
+    background-color: pink;
+    }

--- a/sample/src/main/assets/licenses.html
+++ b/sample/src/main/assets/licenses.html
@@ -72,6 +72,9 @@
     input:checked ~ .license {
     max-height: none;
     }
+    body{
+    background-color: pink;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
This is adding feature pull request.

Add customizable  style section of template html and output html's style is customizable .
For example , if in app's build.gradle
```
licenseTools {
    customStyles = "body{
    background-color: pink;
    }"
}
```
and do `generateLicensePage` task , generated licenses.html's background color is pink.

If you do not set `customStyles` configuration in app's build.gradle and do `generateLicensePage` task ,  generated licenses.html is same in generated made by com.cookpad.android.plugin.license-tools  v1.2.9.