### PR TITLE
Appendable original license

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ licenseTools {
 
 Available configuration fields:
 
-| Field name        | Default value      | Description                                                                                                |
-| ----------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
-| `licensesYaml`    | `"licenses.yml"`   | The name of the licenses yml file                                                                          |
-| `outputHtml`      | `"licenses.html"`  | The file name of the output of the `generateLicensePage` task                                              |
-| `outputJson`      | `"licenses.json"`  | The file name of the output of the `generateLicenseJson` task                                              |
-| `ignoredGroups`   | `[]` (empty array) | An array of group names the plugin will ignore (useful for internal dependencies with missing .pom files)  |
-| `ignoredProjects` | `[]` (empty array) | An array of project names the plugin will ignore (To ignore particular internal projects like custom lint) |
-
+| Field name        | Default value                       | Description                                                                                                              |
+| ----------------- | ------------------------------------| -------------------------------------------------------------------------------------------------------------------------|
+| `licensesYaml`    | `"licenses.yml"`                    | The name of the licenses yml file                                                                                        |
+| `outputHtml`      | `"licenses.html"`                   | The file name of the output of the `generateLicensePage` task                                                            |
+| `outputJson`      | `"licenses.json"`                   | The file name of the output of the `generateLicenseJson` task                                                            |
+| `ignoredGroups`   | `[]` (empty array)                  | An array of group names the plugin will ignore (useful for internal dependencies with missing .pom files)                |
+| `ignoredProjects` | `[]` (empty array)                  | An array of project names the plugin will ignore (To ignore particular internal projects like custom lint)               |
+| `originalLicenses`| `Map<String, String>()` (empty Map) | An Map<String,String> of key is license name and value is license template file that not including this plugin template. |
 ## DataSet Format
 
 ### Required Fields

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/LicenseToolsPluginExtension.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/LicenseToolsPluginExtension.kt
@@ -14,6 +14,8 @@ open class LicenseToolsPluginExtension {
 
     var ignoredProjects = emptySet<String>()
 
+    var originalLicenses = emptyMap<String, String>()
+
     companion object {
         const val NAME = "licenseTools"
     }

--- a/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicensePage.kt
+++ b/plugin/src/main/java/com/cookpad/android/plugin/license/task/GenerateLicensePage.kt
@@ -30,7 +30,7 @@ object GenerateLicensePage {
         this.filterNot { it.skip ?: false }
             .forEach {
                 try {
-                    licenseHtml.append(Templates.buildLicenseHtml(it))
+                    licenseHtml.append(Templates.buildLicenseHtml(it, project))
                 } catch (exception: NotEnoughInformationException) {
                     // Print all libraries aren't enough information for develops to fix them.
                     hasError = true
@@ -41,6 +41,6 @@ object GenerateLicensePage {
             throw GradleException("generateLicensePage: more than one library isn't enough information")
         }
 
-        return Templates.wrapWithLayout(licenseHtml)
+        return Templates.wrapWithLayout(licenseHtml, project)
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -55,6 +55,11 @@ licenseTools {
     ignoredProjects = [
             'plugin',
     ]
+
+    HashMap<String,String> licensesMap = new HashMap()
+    licensesMap.put("ML Kit Terms of Service","mlkit_license.html")
+
+    originalLicenses=licensesMap
 }
 
 dependencies {

--- a/sample/licenses.yml
+++ b/sample/licenses.yml
@@ -190,3 +190,9 @@
   license: The Apache Software License, Version 2.0
   licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
   url: http://www.jetbrains.org
+# for originalLicenses configuration sample code
+- artifact: com.google.android.gms:play-services-mlkit-barcode-scanning:+
+  name: play-services-mlkit-barcode-scanning
+  copyrightHolder: The Android Open Source Project
+  license: ML Kit Terms of Service
+  licenseUrl: https://developers.google.com/ml-kit/terms

--- a/sample/mlkit_license.html
+++ b/sample/mlkit_license.html
@@ -1,0 +1,57 @@
+<div class="library">
+  <!-- https://opensource.org/licenses/GPL-3.0 -->
+  <h1 class="title">${library.name}</h1>
+  <p class="notice">${library.copyrightStatement.replaceAll("\n", "<br/>")}</p>
+  <% print library.url == null || library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a>
+</p>""" %>
+  <input type="checkbox"><label></label>
+  <div class="license">
+    <h1>
+      ML KIT Terms of Service
+    </h1>
+    <div>
+      The following terms apply to your use of ML Kit APIs. These terms incorporate and are subject
+      to the Google APIs Terms of Service.
+    </div>
+    <h2>
+      General Terms
+    </h2>
+    <div>
+      <p>
+        1.For purposes of these terms, machine learning models will be considered related software.
+      </p>
+      <p>
+        2.ML Kit APIs run on-device. When using the ML Kit APIs, you may not reverse engineer or
+        attempt to extract the source code or any related software, except to the extent that this
+        restriction is expressly prohibited by applicable law.
+      </p>
+    </div>
+    <h2>
+      Privacy
+    </h2>
+    <div>
+      <p>
+        When you use ML Kit APIs, processing of the input data (e.g. images, video, text) fully
+        happens on-device, and ML Kit does not send that data to Google servers. As a result, you
+        can use our APIs for processing data that should not leave the device.
+      </p>
+      <p>
+        The ML Kit APIs may contact Google servers from time to time in order to receive things like
+        bug fixes, updated models and hardware accelerator compatibility information. The ML Kit
+        APIs also send metrics about the performance and utilization of the APIs in your app to
+        Google. Google uses this metrics data to measure performance, debug, maintain and improve
+        the APIs, and detect misuse or abuse, as further described in our Privacy Policy.
+      </p>
+      <p>
+        You are responsible for informing users of your app about Google’s processing of ML Kit
+        metrics data as required by applicable law.
+      </p>
+      <p>
+        For additional details to help support your Google Play and Apple App Store disclosures
+        requirements, please refer to:
+      </p>
+      Google Play’s data disclosure requirements<br/>
+      Apple’s App Store data disclosure requirements<br/>
+    </div>
+  </div>
+</div>

--- a/sample/src/main/assets/licenses.html
+++ b/sample/src/main/assets/licenses.html
@@ -7979,7 +7979,51 @@
          <pre>Copyright [yyyy] [name of copyright owner]&#x000A;&#x000A;Licensed under the Apache License, Version 2.0 (the "License");&#x000A;you may not use this file except in compliance with the License.&#x000A;You may obtain a copy of the License at&#x000A;&#x000A;  http://www.apache.org/licenses/LICENSE-2.0&#x000A;&#x000A;Unless required by applicable law or agreed to in writing, software&#x000A;distributed under the License is distributed on an "AS IS" BASIS,&#x000A;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#x000A;See the License for the specific language governing permissions and&#x000A;limitations under the License.</pre>
        </div>
      </div>
-     
+     <div class="library">
+       <!-- https://opensource.org/licenses/GPL-3.0 -->
+       <h1 class="title">play-services-mlkit-barcode-scanning</h1>
+       <p class="notice">Copyright &copy; The Android Open Source Project. All rights reserved.</p>
+       
+       <input type="checkbox"><label></label>
+       <div class="license">
+         <h1>
+         ML KIT Terms of Service
+         </h1>
+         <div>
+         The following terms apply to your use of ML Kit APIs. These terms incorporate and are subject to the Google APIs Terms of Service.
+         </div>
+         <h2>
+         General Terms
+         </h2>
+         <div>
+           <p>
+         1.For purposes of these terms, machine learning models will be considered related software.
+           </p>
+           <p>
+         2.ML Kit APIs run on-device. When using the ML Kit APIs, you may not reverse engineer or attempt to extract the source code or any related software, except to the extent that this restriction is expressly prohibited by applicable law.
+           </p>
+         </div>
+         <h2>
+         Privacy
+         </h2>
+         <div>
+           <p>
+         When you use ML Kit APIs, processing of the input data (e.g. images, video, text) fully happens on-device, and ML Kit does not send that data to Google servers. As a result, you can use our APIs for processing data that should not leave the device.
+           </p>
+           <p>
+         The ML Kit APIs may contact Google servers from time to time in order to receive things like bug fixes, updated models and hardware accelerator compatibility information. The ML Kit APIs also send metrics about the performance and utilization of the APIs in your app to Google. Google uses this metrics data to measure performance, debug, maintain and improve the APIs, and detect misuse or abuse, as further described in our Privacy Policy.
+           </p>
+           <p>
+         You are responsible for informing users of your app about Google’s processing of ML Kit metrics data as required by applicable law.
+           </p>
+           <p>
+         For additional details to help support your Google Play and Apple App Store disclosures requirements, please refer to:
+           </p>
+         Google Play’s data disclosure requirements<br/>
+         Apple’s App Store data disclosure requirements<br/>
+         </div>
+       </div>
+     </div>
 
 </body>
 </html>


### PR DESCRIPTION
This is adding feature pull request.

Be able to Add template of original licenses for output html.
For example , if add `original_license.html` file under app directory and add in app's build.gradle like following 
```
licenseTools {
    HashMap<String,String> licensesMap = new HashMap()
    licensesMap.put("The original License","original_license.html")

    originalLicenses=licensesMap
}
```
and add in  licenses.yml like following 
```
- artifact: com.example.original-package:+
  copyrightHolder: You
  license: The original License
```
, and do `generateLicensePage` task ,  generating licenses.html including content of original_license.html .


If you do not set  originalLicenses configuration in app's build.gradle and do generateLicensePage task , generated licenses.html is same in generated made by com.cookpad.android.plugin.license-tools v1.2.9.

